### PR TITLE
feat: Allow single .dmd file builds via --file option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 www-test
+www

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+www-test

--- a/builder.mjs
+++ b/builder.mjs
@@ -5,12 +5,14 @@ import cmdArgs from 'command-line-args';
 const settings = [
   { name: 'paths', multiple: true, defaultOption: true },
   { name: 'clear-all', alias: 'c', type: Boolean },
-  { name: 'verbose', alias: 'v', type: Boolean }];
+  { name: 'verbose', alias: 'v', type: Boolean },
+  { name: 'file', alias: 'f', type: String }];
 
 const mainOptions = cmdArgs(settings, { stopAtFirstUnknown: true });
     
+// Ensure that the three main path arguments are always provided.
 if (!mainOptions.paths || mainOptions.paths.length !== 3) {
-  throw new Error('Invalid number of parameters: you should provide input, output and layout paths as first 3 parameters.');
+  throw new Error('Invalid number of parameters: you must provide input, output, and layout paths.');
 }
 
 const paths = {

--- a/lib/2static.mjs
+++ b/lib/2static.mjs
@@ -5,8 +5,10 @@ import path from 'path';
 import fs from 'fs';
 import fsx from 'fs-extra';
 import * as utils from './utils.mjs';
+import { fileURLToPath } from 'url';
 
-const __dirname = import.meta.dirname;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const registerHBPartials = () => {
   const dir = path.resolve(__dirname, '../common');
@@ -58,13 +60,33 @@ export const initialize = async (mainOptions, paths, backlinks) => {
 
 export const run = async () => {
   await copyWebsiteAssets().catch((err) => {
-    console.error('\x1b[31m', err, '\x1b[0m');
+    console.error('[31m', err, '[0m');
   });
   
-  console.info(`\x1b[32mWebsite assets where copied to ${_paths.assetsPath}`);
+  console.info(`[32mWebsite assets where copied to ${_paths.assetsPath}`);
   
-  await convertFiles(_paths.inputPath);
-  convertCollectionFiles();
+  if (_mainOptions.file) {
+    // If a single file is specified, process only that file
+    const singleFilePath = path.resolve(_paths.inputPath, _mainOptions.file);
+    
+    // Check if the file exists before trying to render it
+    if (await fsx.pathExists(singleFilePath)) {
+      if (path.extname(singleFilePath) === '.dmd') {
+        await renderDMDToHtml(singleFilePath).catch((err) => {
+          console.error(`[31mError rendering ${singleFilePath}:`, err.message, '[0m');
+        });
+      } else {
+        console.warn(`[33mSpecified file is not a .dmd file: ${singleFilePath}[0m`);
+      }
+    } else {
+      console.warn(`[33mSpecified file not found: ${singleFilePath}[0m`);
+    }
+    // IMPORTANT: Do NOT call convertCollectionFiles when processing a single file.
+  } else {
+    // Original behavior: process all files and then collections
+    await convertFiles(_paths.inputPath);
+    convertCollectionFiles();
+  }
 };
 
 async function copyWebsiteAssets () {

--- a/lib/2static.mjs
+++ b/lib/2static.mjs
@@ -60,10 +60,10 @@ export const initialize = async (mainOptions, paths, backlinks) => {
 
 export const run = async () => {
   await copyWebsiteAssets().catch((err) => {
-    console.error('[31m', err, '[0m');
+    console.error('\x1b[31m', err, '\x1b[0m');
   });
   
-  console.info(`[32mWebsite assets where copied to ${_paths.assetsPath}`);
+  console.info(`\x1b[32mWebsite assets where copied to ${_paths.assetsPath}\x1b[0m`);
   
   if (_mainOptions.file) {
     // If a single file is specified, process only that file
@@ -73,13 +73,13 @@ export const run = async () => {
     if (await fsx.pathExists(singleFilePath)) {
       if (path.extname(singleFilePath) === '.dmd') {
         await renderDMDToHtml(singleFilePath).catch((err) => {
-          console.error(`[31mError rendering ${singleFilePath}:`, err.message, '[0m');
+          console.error(`\x1b[31mError rendering ${singleFilePath}:\x1b[0m`, err.message, '\x1b[0m');
         });
       } else {
-        console.warn(`[33mSpecified file is not a .dmd file: ${singleFilePath}[0m`);
+        console.warn(`\x1b[33mSpecified file is not a .dmd file: ${singleFilePath}\x1b[0m`);
       }
     } else {
-      console.warn(`[33mSpecified file not found: ${singleFilePath}[0m`);
+      console.warn(`\x1b[33mSpecified file not found: ${singleFilePath}\x1b[0m`);
     }
     // IMPORTANT: Do NOT call convertCollectionFiles when processing a single file.
   } else {

--- a/lib/2zettelkasten.mjs
+++ b/lib/2zettelkasten.mjs
@@ -49,7 +49,7 @@ async function processDirectory (inputPath) {
 async function processSingleDmdFile(filePath) {
   try {
     if (!await fsx.pathExists(filePath)) {
-      console.warn(`[33mFile not found in 2zettelkasten: ${filePath}[0m`);
+      console.warn(`\x1b[33mFile not found in 2zettelkasten: ${filePath}\x1b[0m`);
       return;
     }
     // Ensure it's a .dmd file, even if called directly
@@ -85,7 +85,7 @@ async function processSingleDmdFile(filePath) {
       });
     }
   } catch (error) {
-    console.error(`[31mError processing file in 2zettelkasten ${filePath}: ${error.message}[0m`);
+    console.error(`\x1b[31mError processing file in 2zettelkasten ${filePath}: ${error.message}\x1b[0m`);
     // Optionally, re-throw the error if you want to stop the build process
     // throw error; 
   }

--- a/lib/2zettelkasten.mjs
+++ b/lib/2zettelkasten.mjs
@@ -2,55 +2,91 @@ import fsx from 'fs-extra';
 import path from 'path';
 import * as utils from './utils.mjs';
 
-let paths = {};
-let backlinks = [];
+let currentPaths = {}; // Renamed to avoid conflict
+let backlinks = {}; // Initialize as object for associative array usage
 
-export async function buildBacklinks(mainOptions, paths) {
-  paths = paths;
+// Accept mainOptions and newPaths
+export async function buildBacklinks(mainOptions, newPaths) {
+  currentPaths = newPaths; // Store it
+  backlinks = {}; // Reset backlinks for each run
 
-  await processFiles(paths.inputPath);
+  if (mainOptions.file) {
+    // If a single file is specified, process only that file
+    const singleFilePath = path.resolve(currentPaths.inputPath, mainOptions.file);
+    await processSingleDmdFile(singleFilePath);
+  } else {
+    // Otherwise, process all files in the input directory as before
+    await processDirectory(currentPaths.inputPath);
+  }
   
   return backlinks;
 }
 
-async function processFiles (inputPath) {
+// Renamed original processFiles to processDirectory
+async function processDirectory (inputPath) {
   await fsx.ensureDir(inputPath);
   let inputItems = await fsx.readdir(path.resolve(inputPath));
   
   for (let i = 0; i < inputItems.length; i++) {
     let item = inputItems[i];
-    
-    let fullItemPath = `${inputPath}${item}`;
+    let fullItemPath = path.join(inputPath, item); // Use path.join
     let inputStat = await fsx.stat(fullItemPath);
+
     if (inputStat.isDirectory()) {
-      if (item !== 'assets') {
-        await processFiles(`${fullItemPath}/`);
+      // Exclude 'assets' directory from recursive processing for backlinks
+      if (item !== 'assets') { 
+        await processDirectory(fullItemPath); // Recursive call
       }
-    }
-    else {
-      // is a file
+    } else {
       if (path.extname(item) === '.dmd') {
-        let dmdObj = await utils.generateDmdObject(fullItemPath);
-
-        dmdObj.meta.links.forEach((lnk, i) => {
-          let isDmLink = false;
-          isDmLink |= lnk.startsWith('/') && !lnk.startsWith('/assets');
-          isDmLink |= lnk.indexOf('dariomac.com') > -1;
-
-          if (isDmLink) {
-            lnk = path.basename(lnk);
-
-            const title = dmdObj.frontmatter.title === dmdObj.frontmatter.card.title ? 
-              dmdObj.frontmatter.title : 
-              `${dmdObj.frontmatter.title} - ${dmdObj.frontmatter.card.title}`;
-
-            (backlinks[lnk] = backlinks[lnk] || []).push({
-              "backlink": `/${dmdObj.meta.slug}`,
-              "title": title
-            });
-          }
-        });
+        await processSingleDmdFile(fullItemPath); // Process the individual file
       }
     }
+  }
+}
+
+// New function to process a single DMD file
+async function processSingleDmdFile(filePath) {
+  try {
+    if (!await fsx.pathExists(filePath)) {
+      console.warn(`[33mFile not found in 2zettelkasten: ${filePath}[0m`);
+      return;
+    }
+    // Ensure it's a .dmd file, even if called directly
+    if (path.extname(filePath) !== '.dmd') {
+        // console.warn(`[33mSkipping non-DMD file in 2zettelkasten: ${filePath}[0m`);
+        return;
+    }
+    let dmdObj = await utils.generateDmdObject(filePath);
+    if (dmdObj && dmdObj.meta && dmdObj.meta.links) {
+      dmdObj.meta.links.forEach((lnk) => { // Removed unused index i
+        let isDmLink = false;
+        // Ensure lnk is a string before calling startsWith or indexOf
+        if (typeof lnk === 'string') {
+            isDmLink |= lnk.startsWith('/') && !lnk.startsWith('/assets');
+            isDmLink |= lnk.indexOf('dariomac.com') > -1;
+        } else {
+            // console.warn(`[33mEncountered non-string link in ${filePath}: ${JSON.stringify(lnk)}[0m`);
+            return; // Skip this link
+        }
+
+        if (isDmLink) {
+          const baseLnk = path.basename(lnk); 
+
+          const title = dmdObj.frontmatter.title === dmdObj.frontmatter.card.title ? 
+            dmdObj.frontmatter.title : 
+            `${dmdObj.frontmatter.title} - ${dmdObj.frontmatter.card.title}`;
+
+          (backlinks[baseLnk] = backlinks[baseLnk] || []).push({
+            "backlink": `/${dmdObj.meta.slug}`,
+            "title": title
+          });
+        }
+      });
+    }
+  } catch (error) {
+    console.error(`[31mError processing file in 2zettelkasten ${filePath}: ${error.message}[0m`);
+    // Optionally, re-throw the error if you want to stop the build process
+    // throw error; 
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "find . -name '.DS_Store' -type f -delete && node builder.mjs data/ www/ layouts/ --clear-all",
     "build-notes": "find . -name '.DS_Store' -type f -delete && node notes-builder.mjs ../bra1n data/",
     "build-all": "npm run build-notes && npm run build",
+    "build-file": "node builder.mjs data www-test layouts --file",
     "dev": "PORT=7007 node server.mjs",
     "start": "node server.mjs",
     "deploy": "timeout 15 bash -c 'while [[ \"$(curl -s -o /dev/null -X OPTIONS -w ''%{http_code}'' https://dariomac.com/pullit)\" != \"204\" ]]; do sleep 1; done'",


### PR DESCRIPTION
This commit introduces the capability to build a single .dmd file instead of the entire site.

New command-line option:
- `--file <path/to/file.dmd>` (alias `-f`): Specifies the single .dmd file to process. The path should be relative to the input directory.

Changes:
- Modified `builder.mjs` to add the `--file` option and update argument validation. The three main path arguments (input, output, layout) are still required.
- Adjusted `lib/2zettelkasten.mjs` to conditionally build backlinks for only the specified file when `--file` is used.
- Adjusted `lib/2static.mjs` to conditionally render only the specified .dmd file to HTML and skip collection processing when `--file` is used.
- `lib/utils.generateDmdObject` was reviewed and required no changes.
- Added `www-test/` to `.gitignore`.
- Fixed `__dirname` resolution in `lib/2static.mjs` for compatibility with the execution environment.

Testing:
- Verified that full builds remain unaffected.
- Verified that using `--file` processes only the specified file and its assets.
- Verified graceful handling of non-existent files specified with `--file`.